### PR TITLE
Create SSE client for combined SSE events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     cassia-ruby (0.1.0)
       faraday
       faraday_middleware
+      ld-eventsource
       virtus
 
 GEM
@@ -16,6 +17,7 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    concurrent-ruby (1.1.5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
@@ -25,7 +27,13 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
+    hitimes (1.3.1)
+    http_tools (0.4.5)
     ice_nine (0.11.2)
+    ld-eventsource (1.0.0)
+      concurrent-ruby (~> 1.0)
+      http_tools (~> 0.4.5)
+      socketry (~> 0.5.1)
     method_source (0.9.2)
     multipart-post (2.1.1)
     pry (0.12.2)
@@ -45,6 +53,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    socketry (0.5.1)
+      hitimes (~> 1.2)
     thread_safe (0.3.6)
     vcr (5.0.0)
     virtus (1.0.5)

--- a/cassia-ruby.gemspec
+++ b/cassia-ruby.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "virtus"
+  spec.add_dependency "ld-eventsource"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/cassia.rb
+++ b/lib/cassia.rb
@@ -3,6 +3,7 @@ require "faraday_middleware"
 require "virtus"
 require "base64"
 require "json"
+require "ld-eventsource"
 
 require "cassia/api"
 require "cassia/configuration"
@@ -42,6 +43,7 @@ require "cassia/requests/open_connection_state"
 require "cassia/requests/close_connection_state"
 require "cassia/requests/open_ap_state"
 require "cassia/requests/close_ap_state"
+require "cassia/requests/combined_sse"
 
 module Cassia
   def self.configuration

--- a/lib/cassia/access_controller.rb
+++ b/lib/cassia/access_controller.rb
@@ -8,6 +8,7 @@ module Cassia
     attribute :autoselect_switch, Integer, default: 0
     attribute :connected_devices, Array[Cassia::Device], default: []
     attribute :routers, Array[Cassia::Router], default: []
+    attribute :sse
 
     def get_token
       Cassia::Requests::GetToken.new(self).perform
@@ -59,6 +60,20 @@ module Cassia
 
     def close_ap_state
       Cassia::Requests::CloseApState.new(self).perform
+    end
+
+    def combined_sse
+      combined_sse = Cassia::Requests::CombinedSse.new(self)
+
+      self.sse = SSE::Client.new("#{ac_url}#{combined_sse.path}", headers: combined_sse.headers) do |client|
+        yield(client)
+      end
+    end
+
+    private
+
+    def ac_url
+      Cassia.configuration.ac_url
     end
   end
 end

--- a/lib/cassia/requests/combined_sse.rb
+++ b/lib/cassia/requests/combined_sse.rb
@@ -1,0 +1,27 @@
+module Cassia
+  module Requests
+    class CombinedSse
+      def initialize(access_controller)
+        @access_controller = access_controller
+      end
+
+      def path
+        "/api/aps/events"
+      end
+
+      def headers
+        {
+          'Authorization' => "Bearer #{access_token}",
+          'Content-Type' => "application/json"
+        }
+      end
+
+      private
+
+      def access_token
+        @access_controller.get_token if @access_controller.access_token.nil?
+        @access_controller.access_token
+      end
+    end
+  end
+end

--- a/spec/cassettes/access_controller/combined_sse/success.yml
+++ b/spec/cassettes/access_controller/combined_sse/success.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://iteratelabs.cassia.pro/api/oauth2/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials"}'
+    headers:
+      Authorization:
+      - Basic <CREDENTIALS>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx/1.13.6
+      date:
+      - Mon, 08 Jul 2019 21:02:31 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '123'
+      connection:
+      - close
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-headers:
+      - Content-Type,Accept,Authorization
+      access-control-allow-methods:
+      - GET,POST,PUT,DELETE
+      access-control-allow-credentials:
+      - 'true'
+      x-frame-options:
+      - SAMEORIGIN
+      x-content-type-options:
+      - nosniff
+      cache-control:
+      - no-store
+      pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"bearer","access_token":"61f41db0bd5a4d5a006ff349581ace6be94c1b8d8466f86a9b3f0c5a3da0ae6e","expires_in":3600}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:31 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassia/access_controller_spec.rb
+++ b/spec/cassia/access_controller_spec.rb
@@ -2,47 +2,47 @@ require 'spec_helper'
 
 RSpec.describe Cassia::AccessController do
   include FaradayHelpers
-  
+
   describe "#get_token" do
     vcr_options = { cassette_name: 'access_controller/get_token/success', record: :new_episodes }
-      context "when successful", vcr: vcr_options do
-        it "sets the access_token" do
-          access_controller = described_class.new
+    context "when successful", vcr: vcr_options do
+      it "sets the access_token" do
+        access_controller = described_class.new
 
-          access_controller.get_token
+        access_controller.get_token
 
-          expect(access_controller.access_token).not_to be_nil
-        end
+        expect(access_controller.access_token).not_to be_nil
       end
-    
+    end
+
     vcr_options = { cassette_name: 'access_controller/get_token/failure', record: :new_episodes }
-      context "when unsuccessful", vcr: vcr_options do
-        it "sets the error and error_description values" do
-          Cassia.configuration.client_id = "invalid"
-          Cassia.configuration.secret = "invalid"
-          access_controller = described_class.new
+    context "when unsuccessful", vcr: vcr_options do
+      it "sets the error and error_description values" do
+        Cassia.configuration.client_id = "invalid"
+        Cassia.configuration.secret = "invalid"
+        access_controller = described_class.new
 
-          access_controller.get_token
+        access_controller.get_token
 
-          expect(access_controller.error). to eq "invalid_client"
-          expect(access_controller.error_description). to eq "Client not found"
-        end
+        expect(access_controller.error). to eq "invalid_client"
+        expect(access_controller.error_description). to eq "Client not found"
       end
+    end
   end
 
   describe "#get_all_routers_status" do
     vcr_options = { cassette_name: 'access_controller/routersstatus/success', record: :new_episodes }
-      context "when successful", vcr: vcr_options do
-        it "appends routers to the array" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when successful", vcr: vcr_options do
+      it "appends routers to the array" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.get_all_routers_status
+        access_controller.get_all_routers_status
 
-          expect(access_controller.routers).not_to be_empty
-        end
+        expect(access_controller.routers).not_to be_empty
       end
+    end
 
     vcr_options = { cassette_name: 'access_controller/routersstatus/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
@@ -61,29 +61,29 @@ RSpec.describe Cassia::AccessController do
 
   describe "#switch_autoselect" do
     vcr_options = { cassette_name: 'access_controller/switch_autoselect/success_1', record: :new_episodes }
-        context "when successfully switching to 1", vcr: vcr_options do
-          it "sets the switch to 1" do
-            Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-            Cassia.configuration.secret = ENV['CASSIA_SECRET']
-            access_controller = described_class.new
+    context "when successfully switching to 1", vcr: vcr_options do
+      it "sets the switch to 1" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-            access_controller.switch_autoselect(flag: 1)
+        access_controller.switch_autoselect(flag: 1)
 
-            expect(access_controller.autoselect_switch).to eq 1
-          end
-        end
+        expect(access_controller.autoselect_switch).to eq 1
+      end
+    end
 
     vcr_options = { cassette_name: 'access_controller/switch_autoselect/success_0', record: :new_episodes }
-        context "when successfully switching to 0", vcr: vcr_options do
-          it "sets the switch to 0" do
-            access_controller = described_class.new
+    context "when successfully switching to 0", vcr: vcr_options do
+      it "sets the switch to 0" do
+        access_controller = described_class.new
 
-            access_controller.switch_autoselect(flag: 0)
+        access_controller.switch_autoselect(flag: 0)
 
-            expect(access_controller.autoselect_switch).to eq 0
-          end
-        end
-  
+        expect(access_controller.autoselect_switch).to eq 0
+      end
+    end
+
     vcr_options = { cassette_name: 'access_controller/switch_autoselect/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error and error_description values" do
@@ -101,206 +101,223 @@ RSpec.describe Cassia::AccessController do
 
   describe "#open_scan" do
     vcr_options = { cassette_name: 'access_controller/open_scan/failure', record: :new_episodes }
-      context "when unsuccessful", vcr: vcr_options do
-        it "sets the error" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when unsuccessful", vcr: vcr_options do
+      it "sets the error" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.open_scan(aps: ["invalid router mac"])
+        access_controller.open_scan(aps: ["invalid router mac"])
 
-          expect(access_controller.error). to eq "invalid aps"
-        end
+        expect(access_controller.error). to eq "invalid aps"
       end
+    end
   end
 
   describe "#connect_device" do
     vcr_options = { cassette_name: 'access_controller/connect_device/success', record: :new_episodes }
-      context "when successful", vcr: vcr_options do
-        it "sets the device mac address" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when successful", vcr: vcr_options do
+      it "sets the device mac address" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
-          access_controller.connect_device(device_mac: "F3:25:5F:22:35:39")
+        access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
+        access_controller.connect_device(device_mac: "F3:25:5F:22:35:39")
 
-          expect(access_controller.connected_devices).not_to be_empty
-        end
+        expect(access_controller.connected_devices).not_to be_empty
       end
-    
+    end
+
     vcr_options = { cassette_name: 'access_controller/connect_device/failure', record: :new_episodes }
-      context "when unsuccessful" do
-        it "sets the error", vcr: vcr_options do
-          access_controller = described_class.new
+    context "when unsuccessful" do
+      it "sets the error", vcr: vcr_options do
+        access_controller = described_class.new
 
-          access_controller.connect_device(device_mac: ["blah"])
-          
-          expect(access_controller.error). to eq "invalid devices"
-        end
+        access_controller.connect_device(device_mac: ["blah"])
+
+        expect(access_controller.error). to eq "invalid devices"
       end
+    end
   end
 
   describe "#disconnect_device" do
     vcr_options = { cassette_name: 'access_controller/disconnect_device/success', record: :new_episodes }
-      context "when successful", vcr: vcr_options do
-        it "removes the device from connected_devices" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when successful", vcr: vcr_options do
+      it "removes the device from connected_devices" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
-          access_controller.connect_device(device_mac: "F3:25:5F:22:35:39")
-          access_controller.disconnect_device(device_mac: "F3:25:5F:22:35:39")
+        access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
+        access_controller.connect_device(device_mac: "F3:25:5F:22:35:39")
+        access_controller.disconnect_device(device_mac: "F3:25:5F:22:35:39")
 
-          expect(access_controller.connected_devices).to be_empty
-        end
+        expect(access_controller.connected_devices).to be_empty
       end
-    
+    end
+
     vcr_options = { cassette_name: 'access_controller/disconnect_device/failure', record: :new_episodes }
-      context "when unsuccessful" do
-        it "sets the error", vcr: vcr_options do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when unsuccessful" do
+      it "sets the error", vcr: vcr_options do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
-          access_controller.connect_device(device_mac: "F3:25:5F:22:35:39")
-          access_controller.disconnect_device(device_mac: "invalid device mac")
-          
-          expect(access_controller.error). to eq "invalid devices"
-        end
+        access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
+        access_controller.connect_device(device_mac: "F3:25:5F:22:35:39")
+        access_controller.disconnect_device(device_mac: "invalid device mac")
+
+        expect(access_controller.error). to eq "invalid devices"
       end
+    end
   end
 
   describe "#open_notify" do
     vcr_options = { cassette_name: 'access_controller/open_notify/failure', record: :new_episodes }
-      context "when unsuccessful", vcr: vcr_options do
-        it "sets the error" do
-          access_controller = described_class.new
+    context "when unsuccessful", vcr: vcr_options do
+      it "sets the error" do
+        access_controller = described_class.new
 
-          access_controller.open_notify(aps: ["invalid router mac"])
+        access_controller.open_notify(aps: ["invalid router mac"])
 
-          expect(access_controller.error). to eq "invalid aps"
-        end
+        expect(access_controller.error). to eq "invalid aps"
       end
+    end
   end
 
   describe "#close_notify" do
     vcr_options = { cassette_name: 'access_controller/close_notify/failure', record: :new_episodes }
-      context "when unsuccessful", vcr: vcr_options do
-        it "sets the error" do
-          access_controller = described_class.new
+    context "when unsuccessful", vcr: vcr_options do
+      it "sets the error" do
+        access_controller = described_class.new
 
-          access_controller.close_notify(aps: ["invalid router mac"])
+        access_controller.close_notify(aps: ["invalid router mac"])
 
-          expect(access_controller.error). to eq "invalid aps"
-        end
+        expect(access_controller.error). to eq "invalid aps"
       end
+    end
   end
 
   describe "#close_scan" do
     vcr_options = { cassette_name: 'access_controller/close_scan/failure', record: :new_episodes }
-      context "when unsuccessful", vcr: vcr_options do
-        it "sets the error" do
-          access_controller = described_class.new
+    context "when unsuccessful", vcr: vcr_options do
+      it "sets the error" do
+        access_controller = described_class.new
 
-          access_controller.close_notify(aps: ["invalid router mac"])
+        access_controller.close_notify(aps: ["invalid router mac"])
 
-          expect(access_controller.error). to eq "invalid aps"
-        end
+        expect(access_controller.error). to eq "invalid aps"
       end
+    end
   end
 
   describe "#open_connection_state" do
     vcr_options = { cassette_name: 'access_controller/open_connection_state/failure', record: :new_episodes }
-      context "when unsuccessful", vcr: vcr_options do
-        it "sets the error" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when unsuccessful", vcr: vcr_options do
+      it "sets the error" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.close_notify(aps: ["invalid router mac"])
+        access_controller.close_notify(aps: ["invalid router mac"])
 
-          expect(access_controller.error). to eq "invalid aps"
-        end
+        expect(access_controller.error). to eq "invalid aps"
       end
+    end
   end
 
   describe "#close_connection_state" do
     vcr_options = { cassette_name: 'access_controller/close_connection_state/failure', record: :new_episodes }
-      context "when unsuccessful", vcr: vcr_options do
-        it "sets the error" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when unsuccessful", vcr: vcr_options do
+      it "sets the error" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.close_notify(aps: ["invalid router mac"])
+        access_controller.close_notify(aps: ["invalid router mac"])
 
-          expect(access_controller.error). to eq "invalid aps"
-        end
+        expect(access_controller.error). to eq "invalid aps"
       end
+    end
   end
 
   describe "#open_ap_state" do
     vcr_options = { cassette_name: 'access_controller/open_ap_state/success', record: :new_episodes }
-      context "when successful", vcr: vcr_options do
-        it "turns on ap_state_monitor_on for all routers" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when successful", vcr: vcr_options do
+      it "turns on ap_state_monitor_on for all routers" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.open_ap_state
+        access_controller.open_ap_state
 
-          access_controller.routers.each do |router|
-            expect(router.ap_state_monitor_on).to be_truthy
-          end
+        access_controller.routers.each do |router|
+          expect(router.ap_state_monitor_on).to be_truthy
         end
       end
-    
+    end
+
     vcr_options = { cassette_name: 'access_controller/open_ap_state/failure', record: :new_episodes }
-      context "when unsuccessful" do
-        it "sets the error", vcr: vcr_options do
-          Cassia.configuration.client_id = "invalid client id"
-          Cassia.configuration.secret = "invalid secret"
-          access_controller = described_class.new
+    context "when unsuccessful" do
+      it "sets the error", vcr: vcr_options do
+        Cassia.configuration.client_id = "invalid client id"
+        Cassia.configuration.secret = "invalid secret"
+        access_controller = described_class.new
 
-          access_controller.open_ap_state
-          
-          expect(access_controller.error). to eq "access_denied"
-          expect(access_controller.error_description).to eq "Wrong authorization header"
-        end
+        access_controller.open_ap_state
+
+        expect(access_controller.error). to eq "access_denied"
+        expect(access_controller.error_description).to eq "Wrong authorization header"
       end
+    end
   end
 
   describe "#open_ap_state" do
     vcr_options = { cassette_name: 'access_controller/close_ap_state/success', record: :new_episodes }
-      context "when successful", vcr: vcr_options do
-        it "turns on ap_state_monitor_on for all routers" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
-          access_controller = described_class.new
+    context "when successful", vcr: vcr_options do
+      it "turns on ap_state_monitor_on for all routers" do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
 
-          access_controller.close_ap_state
+        access_controller.close_ap_state
 
-          access_controller.routers.each do |router|
-            expect(router.ap_state_monitor_on).to be_falsey
-          end
+        access_controller.routers.each do |router|
+          expect(router.ap_state_monitor_on).to be_falsey
         end
       end
-    
+    end
+
     vcr_options = { cassette_name: 'access_controller/close_ap_state/failure', record: :new_episodes }
-      context "when unsuccessful" do
-        it "sets the error", vcr: vcr_options do
-          Cassia.configuration.client_id = "invalid client id"
-          Cassia.configuration.secret = "invalid secret"
-          access_controller = described_class.new
+    context "when unsuccessful" do
+      it "sets the error", vcr: vcr_options do
+        Cassia.configuration.client_id = "invalid client id"
+        Cassia.configuration.secret = "invalid secret"
+        access_controller = described_class.new
 
-          access_controller.close_ap_state
-          
-          expect(access_controller.error). to eq "access_denied"
-          expect(access_controller.error_description).to eq "Wrong authorization header"
-        end
+        access_controller.close_ap_state
+
+        expect(access_controller.error). to eq "access_denied"
+        expect(access_controller.error_description).to eq "Wrong authorization header"
       end
+    end
+  end
+
+  describe "#combined_sse" do
+    vcr_options = { cassette_name: 'access_controller/combined_sse/success', record: :new_episodes }
+    context "when successful" do
+      it "takes the body and yields it", vcr: vcr_options do
+        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
+        Cassia.configuration.secret = ENV['CASSIA_SECRET']
+        access_controller = described_class.new
+
+        access_controller.combined_sse do |client|
+          client.close
+        end
+
+        expect(access_controller.sse).not_to be_nil
+      end
+    end
   end
 end

--- a/spec/cassia/requests/close_notify_spec.rb
+++ b/spec/cassia/requests/close_notify_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cassia::Requests::CloseNotify do
   describe '#body' do
     it "returns the correct request" do
       request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"])
-      
+
       expect(request.body).to eq(
         {
           'aps' => ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"]
@@ -43,7 +43,7 @@ RSpec.describe Cassia::Requests::CloseNotify do
           Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
           Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:F1:E8"])
-          
+
           response = request.perform
 
           expect(response).to be_truthy
@@ -56,7 +56,7 @@ RSpec.describe Cassia::Requests::CloseNotify do
           Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
           Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["invalid router mac"])
-          
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/combined_sse_spec.rb
+++ b/spec/cassia/requests/combined_sse_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe Cassia::Requests::CombinedSse do
+  describe '#path' do
+    it "returns the correct API endpoint" do
+      request = described_class.new(Cassia::AccessController.new)
+
+      expect(request.path).to eq('/api/aps/events')
+    end
+  end
+
+  describe '#headers' do
+    it "returns the correct authorization and content-type" do
+      access_controller = Cassia::AccessController.new
+      access_controller.access_token = "2ded2d8cf3073d368fec27243a71f858e9b9231d7388e63e6d2f70852c33e66f"
+      request = described_class.new(access_controller)
+
+      expect(request.headers).to eq(
+        {
+          'Authorization' => "Bearer #{access_controller.access_token}",
+          'Content-Type' => "application/json"
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
With this we will add the ld-eventsource gem which gives us a SSE
client to receive the combined SSE events sent to the access controller.
With this we can now operate on events sent to us by the access controller
from our routers.