### PR TITLE
Add environment helper for testing

### DIFF
--- a/spec/cassia/access_controller_spec.rb
+++ b/spec/cassia/access_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Cassia::AccessController do
   include FaradayHelpers
+  include EnvironmentHelpers
 
   describe "#get_token" do
     vcr_options = { cassette_name: 'access_controller/get_token/success', record: :new_episodes }
@@ -18,14 +19,14 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/get_token/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error and error_description values" do
-        Cassia.configuration.client_id = "invalid"
-        Cassia.configuration.secret = "invalid"
-        access_controller = described_class.new
+        with_environment('CASSIA_CLIENT_ID' => 'invalid', 'CASSIA_SECRET' => 'invalid') do
+          access_controller = described_class.new
 
-        access_controller.get_token
+          access_controller.get_token
 
-        expect(access_controller.error). to eq "invalid_client"
-        expect(access_controller.error_description). to eq "Client not found"
+          expect(access_controller.error). to eq "invalid_client"
+          expect(access_controller.error_description). to eq "Client not found"
+        end
       end
     end
   end
@@ -34,8 +35,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/routersstatus/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "appends routers to the array" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.get_all_routers_status
@@ -47,14 +46,14 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/routersstatus/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error and error_description values" do
-        Cassia.configuration.client_id = "invalid"
-        Cassia.configuration.secret = "invalid"
-        access_controller = described_class.new
+        with_environment('CASSIA_CLIENT_ID' => 'invalid', 'CASSIA_SECRET' => 'invalid') do
+          access_controller = described_class.new
 
-        access_controller.get_all_routers_status
+          access_controller.get_all_routers_status
 
-        expect(access_controller.error). to eq "access_denied"
-        expect(access_controller.error_description). to eq "Wrong authorization header"
+          expect(access_controller.error). to eq "access_denied"
+          expect(access_controller.error_description). to eq "Wrong authorization header"
+        end
       end
     end
   end
@@ -63,8 +62,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/switch_autoselect/success_1', record: :new_episodes }
     context "when successfully switching to 1", vcr: vcr_options do
       it "sets the switch to 1" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.switch_autoselect(flag: 1)
@@ -87,14 +84,14 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/switch_autoselect/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error and error_description values" do
-        Cassia.configuration.client_id = "invalid"
-        Cassia.configuration.secret = "invalid"
-        access_controller = described_class.new
+        with_environment('CASSIA_CLIENT_ID' => 'invalid', 'CASSIA_SECRET' => 'invalid') do
+          access_controller = described_class.new
 
-        access_controller.switch_autoselect(flag: 0)
+          access_controller.switch_autoselect(flag: 0)
 
-        expect(access_controller.error). to eq "access_denied"
-        expect(access_controller.error_description). to eq "Wrong authorization header"
+          expect(access_controller.error). to eq "access_denied"
+          expect(access_controller.error_description). to eq "Wrong authorization header"
+        end
       end
     end
   end
@@ -103,8 +100,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/open_scan/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.open_scan(aps: ["invalid router mac"])
@@ -118,8 +113,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/connect_device/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the device mac address" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
@@ -145,8 +138,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/disconnect_device/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "removes the device from connected_devices" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
@@ -160,8 +151,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/disconnect_device/failure', record: :new_episodes }
     context "when unsuccessful" do
       it "sets the error", vcr: vcr_options do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.open_scan(aps: ["CC:1B:E0:E0:F1:E8"])
@@ -216,8 +205,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/open_connection_state/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.close_notify(aps: ["invalid router mac"])
@@ -231,8 +218,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/close_connection_state/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.close_notify(aps: ["invalid router mac"])
@@ -246,8 +231,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/open_ap_state/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "turns on ap_state_monitor_on for all routers" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.open_ap_state
@@ -261,14 +244,14 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/open_ap_state/failure', record: :new_episodes }
     context "when unsuccessful" do
       it "sets the error", vcr: vcr_options do
-        Cassia.configuration.client_id = "invalid client id"
-        Cassia.configuration.secret = "invalid secret"
-        access_controller = described_class.new
+        with_environment('CASSIA_CLIENT_ID' => 'invalid client id', 'CASSIA_SECRET' => 'invalid secret') do
+          access_controller = described_class.new
 
-        access_controller.open_ap_state
+          access_controller.open_ap_state
 
-        expect(access_controller.error). to eq "access_denied"
-        expect(access_controller.error_description).to eq "Wrong authorization header"
+          expect(access_controller.error). to eq "access_denied"
+          expect(access_controller.error_description).to eq "Wrong authorization header"
+        end
       end
     end
   end
@@ -277,8 +260,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/close_ap_state/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "turns on ap_state_monitor_on for all routers" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.close_ap_state
@@ -292,14 +273,14 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/close_ap_state/failure', record: :new_episodes }
     context "when unsuccessful" do
       it "sets the error", vcr: vcr_options do
-        Cassia.configuration.client_id = "invalid client id"
-        Cassia.configuration.secret = "invalid secret"
-        access_controller = described_class.new
+        with_environment('CASSIA_CLIENT_ID' => 'invalid client id', 'CASSIA_SECRET' => 'invalid secret') do
+          access_controller = described_class.new
 
-        access_controller.close_ap_state
+          access_controller.close_ap_state
 
-        expect(access_controller.error). to eq "access_denied"
-        expect(access_controller.error_description).to eq "Wrong authorization header"
+          expect(access_controller.error). to eq "access_denied"
+          expect(access_controller.error_description).to eq "Wrong authorization header"
+        end
       end
     end
   end
@@ -308,8 +289,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/combined_sse/success', record: :new_episodes }
     context "when successful" do
       it "takes the body and yields it", vcr: vcr_options do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
 
         access_controller.combined_sse do |client|
@@ -325,8 +304,6 @@ RSpec.describe Cassia::AccessController do
     vcr_options = { cassette_name: 'access_controller/discover_all_services/success', record: :new_episodes }
       context "when successful", vcr: vcr_options do
         it "sets the services for a router" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = described_class.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -337,23 +314,21 @@ RSpec.describe Cassia::AccessController do
           service1 = Cassia::Service.new(handle: 1, primary: true, uuid: "00001800-0000-1000-8000-00805f9b34fb")
           service2 = Cassia::Service.new(handle: 10, primary: true, uuid: "00001801-0000-1000-8000-00805f9b34fb")
           service3 = Cassia::Service.new(handle: 11, primary: true, uuid: "6e400001-b5a3-f393-e0a9-e50e24dcca9e")
-          
+
           expect(access_controller.connected_devices[0].services).to eq([service1, service2, service3])
         end
       end
-    
+
     vcr_options = { cassette_name: 'access_controller/discover_all_services/failure', record: :new_episodes }
       context "when unsuccessful" do
         it "sets the error", vcr: vcr_options do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = described_class.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
 
           access_controller.discover_all_services(router: router, device_mac: "F6:12:3D:BD:DE:40")
-          
+
           expect(access_controller.error). to eq "device disconnect"
         end
       end
@@ -363,8 +338,6 @@ RSpec.describe Cassia::AccessController do
   vcr_options = { cassette_name: 'access_controller/discover_all_char/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the characteristics for a router" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -378,23 +351,21 @@ RSpec.describe Cassia::AccessController do
         char4 = Cassia::Characteristic.new(uuid: "00002aa6-0000-1000-8000-00805f9b34fb", handle: 9, properties: 2)
         char5 = Cassia::Characteristic.new(uuid: "6e400003-b5a3-f393-e0a9-e50e24dcca9e", handle: 13, properties: 16)
         char6 = Cassia::Characteristic.new(uuid: "6e400002-b5a3-f393-e0a9-e50e24dcca9e", handle: 16, properties: 12)
-        
+
         expect(access_controller.connected_devices[0].characteristics).to eq [char1, char2, char3, char4, char5, char6]
       end
     end
-  
+
   vcr_options = { cassette_name: 'access_controller/discover_all_char/failure', record: :new_episodes }
     context "when unsuccessful" do
       it "sets the error", vcr: vcr_options do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
         connect_res = connect_req.perform
 
         access_controller.discover_all_char(router: router, device_mac: "F6:12:3D:BD:DE:40")
-        
+
         expect(access_controller.error). to eq "device disconnect"
       end
     end
@@ -404,8 +375,6 @@ RSpec.describe Cassia::AccessController do
   vcr_options = { cassette_name: 'access_controller/discover_char_of_service/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the characteristics for a service" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -419,16 +388,14 @@ RSpec.describe Cassia::AccessController do
         char2 = Cassia::Characteristic.new(uuid: "00002a01-0000-1000-8000-00805f9b34fb", handle: 5, properties: 2)
         char3 = Cassia::Characteristic.new(uuid: "00002a04-0000-1000-8000-00805f9b34fb", handle: 7, properties: 2)
         char4 = Cassia::Characteristic.new(uuid: "00002aa6-0000-1000-8000-00805f9b34fb", handle: 9, properties: 2)
-        
+
         expect(access_controller.connected_devices[0].characteristics).to eq [char1, char2, char3, char4]
       end
     end
-  
+
   vcr_options = { cassette_name: 'access_controller/discover_char_of_service/failure', record: :new_episodes }
     context "when unsuccessful" do
       it "sets the error", vcr: vcr_options do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -437,7 +404,7 @@ RSpec.describe Cassia::AccessController do
         service_res = service_req.perform
 
         access_controller.discover_char_of_service(router: router, device_mac: "F6:12:3D:BD:DE:44", service_uuid: "11001800-0000-1000-8000-00805f9b34fb")
-        
+
         expect(access_controller.error). to eq "Service Not Found"
       end
     end
@@ -447,8 +414,6 @@ RSpec.describe Cassia::AccessController do
   vcr_options = { cassette_name: 'access_controller/discover_descriptor_of_char/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the descriptors of a characteristic" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -462,12 +427,10 @@ RSpec.describe Cassia::AccessController do
         expect(char.descriptors).to eq [{"handle"=>3, "uuid"=>"00002a00-0000-1000-8000-00805f9b34fb"}]
       end
     end
-  
+
   vcr_options = { cassette_name: 'access_controller/discover_descriptor_of_char/failure', record: :new_episodes }
     context "when unsuccessful" do
       it "sets the error", vcr: vcr_options do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -476,7 +439,7 @@ RSpec.describe Cassia::AccessController do
         char_res = char_req.perform
 
         access_controller.discover_descriptor_of_char(router: router, device_mac: "F6:12:3D:BD:DE:44", char_uuid: "11002a00-0000-1000-8000-00805f9b34fb")
-        
+
         expect(access_controller.error). to eq "Desciptors Empty. Characteristic Not Found."
       end
     end
@@ -486,8 +449,6 @@ RSpec.describe Cassia::AccessController do
   vcr_options = { cassette_name: 'access_controller/discover_all_services_and_chars/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the characteristics of a service and appends it to services" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -502,24 +463,22 @@ RSpec.describe Cassia::AccessController do
         char5 = Cassia::Characteristic.new(uuid: "6e400003-b5a3-f393-e0a9-e50e24dcca9e", handle: 13, properties: 16, descriptors: [{"handle"=>13, "uuid"=>"6e400003-b5a3-f393-e0a9-e50e24dcca9e"}, {"handle"=>14, "uuid"=>"00002902-0000-1000-8000-00805f9b34fb"}])
         char6 = Cassia::Characteristic.new(uuid: "6e400002-b5a3-f393-e0a9-e50e24dcca9e", handle: 16, properties: 12, descriptors: [{"handle"=>16, "uuid"=>"6e400002-b5a3-f393-e0a9-e50e24dcca9e"}])
         service1 = Cassia::Service.new(uuid: "00001800-0000-1000-8000-00805f9b34fb", primary: true, characteristics: [char1, char2, char3, char4], handle: 1)
-        
+
         expect(access_controller.connected_devices[0].characteristics).to eq [char1, char2, char3, char4, char5, char6]
         expect(access_controller.connected_devices[0].services).to include service1
       end
     end
-  
+
   vcr_options = { cassette_name: 'access_controller/discover_all_services_and_chars/failure', record: :new_episodes }
     context "when unsuccessful" do
       it "sets the error", vcr: vcr_options do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
         connect_res = connect_req.perform
 
         access_controller.discover_all_services_and_chars(router: router, device_mac: "F6:12:3D:BD:DE:40")
-        
+
         expect(access_controller.error). to eq "device disconnect"
       end
     end
@@ -529,8 +488,6 @@ RSpec.describe Cassia::AccessController do
   vcr_options = { cassette_name: 'access_controller/write_char_by_handle/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the notification_on attribute to true of a characteristic" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -539,14 +496,12 @@ RSpec.describe Cassia::AccessController do
         char_res = char_req.perform
 
         access_controller.write_char_by_handle(router: router, device_mac: "F6:12:3D:BD:DE:44", handle: 3, value: "0100")
-        
+
         char = access_controller.connected_devices[0].characteristics.detect {|char| char.handle == 3}
         expect(char.notification_on).to eq true
       end
 
       it "sets the notification_on attribute to false of a characteristic" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -560,12 +515,10 @@ RSpec.describe Cassia::AccessController do
         expect(char.notification_on).to eq false
       end
     end
-  
+
   vcr_options = { cassette_name: 'access_controller/write_char_by_handle/failure', record: :new_episodes }
     context "when unsuccessful" do
       it "sets the error", vcr: vcr_options do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -574,7 +527,7 @@ RSpec.describe Cassia::AccessController do
         char_res = char_req.perform
 
         access_controller.write_char_by_handle(router: router, device_mac: "F6:12:3D:BD:DE:44", handle: 100, value: "0100")
-        
+
         expect(access_controller.error). to eq "Characteristic With Given Handle Not Found"
       end
     end

--- a/spec/cassia/requests/close_ap_state_spec.rb
+++ b/spec/cassia/requests/close_ap_state_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Cassia::Requests::CloseApState do
+  include EnvironmentHelpers
+
   describe '#path' do
     it "returns the correct API endpoint" do
       request = described_class.new(Cassia::AccessController.new)
@@ -28,10 +30,8 @@ RSpec.describe Cassia::Requests::CloseApState do
     vcr_options = { cassette_name: 'close_ap_state/success', record: :new_episodes }
       context "when passing in valid aps", vcr: vcr_options do
         it "returns a 202" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new)
-          
+
           response = request.perform
 
           expect(response).to be_truthy
@@ -41,13 +41,15 @@ RSpec.describe Cassia::Requests::CloseApState do
     vcr_options = { cassette_name: 'close_ap_state/failure', record: :new_episodes }
       context "when passing invalid aps", vcr: vcr_options do
         it "returns a 403" do
-          Cassia.configuration.client_id = "invalid client id"
-          Cassia.configuration.secret = "invalid secret"
-          request = described_class.new(Cassia::AccessController.new)
-          
-          response = request.perform
+          with_environment('CASSIA_CLIENT_ID' => 'invalid client id', 'CASSIA_SECRET' => 'invalid secret') do
+            Cassia.configuration.client_id = "invalid client id"
+            Cassia.configuration.secret = "invalid secret"
+            request = described_class.new(Cassia::AccessController.new)
 
-          expect(response).to be_falsey
+            response = request.perform
+
+            expect(response).to be_falsey
+          end
         end
       end
   end

--- a/spec/cassia/requests/close_connection_state_spec.rb
+++ b/spec/cassia/requests/close_connection_state_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cassia::Requests::CloseConnectionState do
   describe '#body' do
     it "returns the correct request" do
       request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"])
-      
+
       expect(request.body).to eq(
         {
           'aps' => ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"]
@@ -40,10 +40,8 @@ RSpec.describe Cassia::Requests::CloseConnectionState do
     vcr_options = { cassette_name: 'close_connection_state/success', record: :new_episodes }
       context "when passing in valid aps", vcr: vcr_options do
         it "returns a 202" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:F1:E8"])
-          
+
           response = request.perform
 
           expect(response).to be_truthy
@@ -53,10 +51,8 @@ RSpec.describe Cassia::Requests::CloseConnectionState do
     vcr_options = { cassette_name: 'close_connection_state/failure', record: :new_episodes }
       context "when passing invalid aps", vcr: vcr_options do
         it "returns a 400" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["invalid router mac"])
-          
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/close_notify_spec.rb
+++ b/spec/cassia/requests/close_notify_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe Cassia::Requests::CloseNotify do
     vcr_options = { cassette_name: 'close_notify/success', record: :new_episodes }
       context "when passing in valid aps", vcr: vcr_options do
         it "returns a 202" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:F1:E8"])
 
           response = request.perform
@@ -53,8 +51,6 @@ RSpec.describe Cassia::Requests::CloseNotify do
     vcr_options = { cassette_name: 'close_notify/failure', record: :new_episodes }
       context "when passing invalid aps", vcr: vcr_options do
         it "returns a 400" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["invalid router mac"])
 
           response = request.perform

--- a/spec/cassia/requests/close_scan_spec.rb
+++ b/spec/cassia/requests/close_scan_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cassia::Requests::CloseScan do
   describe '#body' do
     it "returns the correct request" do
       request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"])
-      
+
       expect(request.body).to eq(
         {
           'aps' => ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"]
@@ -40,10 +40,8 @@ RSpec.describe Cassia::Requests::CloseScan do
     vcr_options = { cassette_name: 'close_scan/success', record: :new_episodes }
       context "when passing in valid aps", vcr: vcr_options do
         it "returns a 202" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:F1:E8"])
-          
+
           response = request.perform
 
           expect(response).to be_truthy
@@ -53,10 +51,8 @@ RSpec.describe Cassia::Requests::CloseScan do
     vcr_options = { cassette_name: 'close_scan/failure', record: :new_episodes }
       context "when passing invalid aps", vcr: vcr_options do
         it "returns a 400" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["invalid router mac"])
-          
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/connect_device_spec.rb
+++ b/spec/cassia/requests/connect_device_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cassia::Requests::ConnectDevice do
   describe '#body' do
     it "returns the correct aps and devices" do
       request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"], device_mac: "CC:1B:E0:E0:ED:AC" )
-      
+
       expect(request.body).to eq(
         {
           'aps' => ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"],
@@ -41,8 +41,6 @@ RSpec.describe Cassia::Requests::ConnectDevice do
     vcr_options = { cassette_name: 'connect_device/success', record: :new_episodes }
       context "when passing in valid aps and MAC", vcr: vcr_options do
         it "returns the correct response" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           scan_req = Cassia::Requests::OpenScan.new(access_controller, aps: ["CC:1B:E0:E0:F1:E8"])
           scan_res = scan_req.perform
@@ -50,7 +48,7 @@ RSpec.describe Cassia::Requests::ConnectDevice do
             device_mac: "F3:25:5F:22:35:39" )
 
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -58,10 +56,8 @@ RSpec.describe Cassia::Requests::ConnectDevice do
     vcr_options = { cassette_name: 'connect_device/failure', record: :new_episodes }
       context "when passing invalid aps or MAC", vcr: vcr_options do
         it "returns a 400 and error message invalid devices" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, device_mac: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"])
-          
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/connect_local_spec.rb
+++ b/spec/cassia/requests/connect_local_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Cassia::Requests::ConnectLocal do
       router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
       request = described_class.new(Cassia::AccessController.new, router: router,
       device_mac: "F3:25:5F:22:35:39", type: "public", timeout: '6000', auto: '1', discovergatt: '0' )
-      
+
       expect(request.body).to eq(
-        { 
+        {
           'type' => "public",
           'timeout' => '6000',
           'auto' => '1',
@@ -46,14 +46,12 @@ RSpec.describe Cassia::Requests::ConnectLocal do
     vcr_options = { cassette_name: 'connect_local/success', record: :new_episodes }
       context "when passing in valid router and device_mac", vcr: vcr_options do
         it "returns true" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
-         
+
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -61,11 +59,9 @@ RSpec.describe Cassia::Requests::ConnectLocal do
     vcr_options = { cassette_name: 'connect_local/failure', record: :new_episodes }
       context "when passing in invalid device_mac", vcr: vcr_options do
         it "returns false" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
-          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac", type: "random")          
+          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac", type: "random")
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/disconnect_device_spec.rb
+++ b/spec/cassia/requests/disconnect_device_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cassia::Requests::DisconnectDevice do
   describe '#body' do
     it "returns the correct device" do
       request = described_class.new(Cassia::AccessController.new, device_mac: "F6:12:3D:BD:DE:44" )
-      
+
       expect(request.body).to eq(
         {
           'devices' => ["F6:12:3D:BD:DE:44"]
@@ -40,8 +40,6 @@ RSpec.describe Cassia::Requests::DisconnectDevice do
     vcr_options = { cassette_name: 'disconnect_device/success', record: :new_episodes }
       context "when passing in a valid device_mac", vcr: vcr_options do
         it "returns the correct response" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           autoselect_req = Cassia::Requests::SwitchAutoselect.new(access_controller, flag: 1)
           autoselect_res = autoselect_req.perform
@@ -52,7 +50,7 @@ RSpec.describe Cassia::Requests::DisconnectDevice do
           request = described_class.new(access_controller, device_mac: "F6:12:3D:BD:DE:44" )
 
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -68,7 +66,7 @@ RSpec.describe Cassia::Requests::DisconnectDevice do
           connect_req = Cassia::Requests::ConnectDevice.new(access_controller, device_mac: "F6:12:3D:BD:DE:44")
           connect_res = connect_req.perform
           request = described_class.new(Cassia::AccessController.new, device_mac: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"])
-          
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/disconnect_local_spec.rb
+++ b/spec/cassia/requests/disconnect_local_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Cassia::Requests::DisconnectLocal do
     vcr_options = { cassette_name: 'disconnect_local/success', record: :new_episodes }
       context "when passing in valid router and device_mac", vcr: vcr_options do
         it "returns true" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -38,7 +36,7 @@ RSpec.describe Cassia::Requests::DisconnectLocal do
           request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
 
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -46,13 +44,11 @@ RSpec.describe Cassia::Requests::DisconnectLocal do
     vcr_options = { cassette_name: 'disconnect_local/failure', record: :new_episodes }
       context "when passing in invalid device_mac", vcr: vcr_options do
         it "returns false" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
-          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac")          
+          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac")
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/discover_all_char_spec.rb
+++ b/spec/cassia/requests/discover_all_char_spec.rb
@@ -29,16 +29,14 @@ RSpec.describe Cassia::Requests::DiscoverAllChar do
     vcr_options = { cassette_name: 'discover_all_char/success', record: :new_episodes }
       context "when passing in a valid router and device_mac", vcr: vcr_options do
         it "returns true" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
           request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
-         
+
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -46,14 +44,12 @@ RSpec.describe Cassia::Requests::DiscoverAllChar do
     vcr_options = { cassette_name: 'discover_all_char/failure', record: :new_episodes }
       context "when passing in an invalid device_mac", vcr: vcr_options do
         it "returns false" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
-          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac")          
-          
+          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac")
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/discover_all_services_and_chars_spec.rb
+++ b/spec/cassia/requests/discover_all_services_and_chars_spec.rb
@@ -29,16 +29,14 @@ RSpec.describe Cassia::Requests::DiscoverAllServicesAndChars do
     vcr_options = { cassette_name: 'discover_all_services_and_chars/success', record: :new_episodes }
       context "when passing in a valid router and device_mac", vcr: vcr_options do
         it "returns true" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
           request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
-         
+
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -46,14 +44,12 @@ RSpec.describe Cassia::Requests::DiscoverAllServicesAndChars do
     vcr_options = { cassette_name: 'discover_all_services_and_chars/failure', record: :new_episodes }
       context "when passing in an invalid device_mac", vcr: vcr_options do
         it "returns false" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
-          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac")          
-          
+          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac")
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/discover_all_services_spec.rb
+++ b/spec/cassia/requests/discover_all_services_spec.rb
@@ -29,16 +29,14 @@ RSpec.describe Cassia::Requests::DiscoverAllServices do
     vcr_options = { cassette_name: 'discover_all_services/success', record: :new_episodes }
       context "when passing in valid router and device_mac", vcr: vcr_options do
         it "returns true" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
           request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
-         
+
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -46,14 +44,12 @@ RSpec.describe Cassia::Requests::DiscoverAllServices do
     vcr_options = { cassette_name: 'discover_all_services/failure', record: :new_episodes }
       context "when passing in invalid device_mac", vcr: vcr_options do
         it "returns false" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
-          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac")          
-          
+          request = described_class.new(access_controller, router: router, device_mac: "invalid_device_mac")
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/discover_char_of_service_spec.rb
+++ b/spec/cassia/requests/discover_char_of_service_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Cassia::Requests::DiscoverCharOfService do
     vcr_options = { cassette_name: 'discover_char_of_service/success', record: :new_episodes }
       context "when passing in valid router, device_mac, and service_uuid", vcr: vcr_options do
         it "returns true" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -38,9 +36,9 @@ RSpec.describe Cassia::Requests::DiscoverCharOfService do
           service_req = Cassia::Requests::DiscoverAllServices.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
           service_res = service_req.perform
           request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", service_uuid: "00001800-0000-1000-8000-00805f9b34fb")
-         
+
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -48,16 +46,14 @@ RSpec.describe Cassia::Requests::DiscoverCharOfService do
     vcr_options = { cassette_name: 'discover_char_of_service/failure', record: :new_episodes }
       context "when passing in an invalid service_uuid", vcr: vcr_options do
         it "returns false" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
           service_req = Cassia::Requests::DiscoverAllServices.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
           service_res = service_req.perform
-          request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", service_uuid: "11001800-0000-1000-8000-00805f9b34fb")          
-          
+          request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", service_uuid: "11001800-0000-1000-8000-00805f9b34fb")
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/discover_descriptor_of_char_spec.rb
+++ b/spec/cassia/requests/discover_descriptor_of_char_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Cassia::Requests::DiscoverDescriptorOfChar do
     vcr_options = { cassette_name: 'discover_descriptor_of_char/success', record: :new_episodes }
       context "when passing in valid router, device_mac, and char_uuid", vcr: vcr_options do
         it "returns true" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -38,9 +36,9 @@ RSpec.describe Cassia::Requests::DiscoverDescriptorOfChar do
           char_req = Cassia::Requests::DiscoverAllChar.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
           char_res = char_req.perform
           request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", char_uuid: "00002a00-0000-1000-8000-00805f9b34fb")
-         
+
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -48,16 +46,14 @@ RSpec.describe Cassia::Requests::DiscoverDescriptorOfChar do
     vcr_options = { cassette_name: 'discover_descriptor_of_char/failure', record: :new_episodes }
       context "when passing in an invalid char_uuid", vcr: vcr_options do
         it "returns false" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
           char_req = Cassia::Requests::DiscoverAllChar.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
           char_res = char_req.perform
-          request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", char_uuid: "11002a00-0000-1000-8000-00805f9b34fb")          
-          
+          request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", char_uuid: "11002a00-0000-1000-8000-00805f9b34fb")
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/get_all_routers_status_spec.rb
+++ b/spec/cassia/requests/get_all_routers_status_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe Cassia::Requests::GetAllRoutersStatus do
     vcr_options = { cassette_name: 'routersstatus/success', record: :new_episodes }
     context "when passing valid credentials", vcr: vcr_options do
       it "returns true" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         request = described_class.new(access_controller)
 
@@ -45,7 +43,7 @@ RSpec.describe Cassia::Requests::GetAllRoutersStatus do
         access_controller = Cassia::AccessController.new
         access_controller.access_token = "invalid_access_token"
         request = described_class.new(access_controller)
-        
+
         response = request.perform
 
         expect(response).to be_falsey

--- a/spec/cassia/requests/get_connected_devices_router_spec.rb
+++ b/spec/cassia/requests/get_connected_devices_router_spec.rb
@@ -30,8 +30,6 @@ RSpec.describe Cassia::Requests::GetConnectedDevicesRouter do
     vcr_options = { cassette_name: 'get_connected_devices_router/success', record: :new_episodes }
     context "when passing a valid router", vcr: vcr_options do
       it "returns true" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         request = described_class.new(access_controller, router: router)
@@ -45,8 +43,6 @@ RSpec.describe Cassia::Requests::GetConnectedDevicesRouter do
     vcr_options = { cassette_name: 'get_connected_devices_router/failure', record: :new_episodes }
     context "when passing an invalid router", vcr: vcr_options do
       it "returns false" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = Cassia::Router.new(mac: "invalid router mac")
         request = described_class.new(access_controller, router: router)

--- a/spec/cassia/requests/get_token_spec.rb
+++ b/spec/cassia/requests/get_token_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Cassia::Requests::GetToken do
+  include EnvironmentHelpers
   describe '#path' do
     it "returns the correct API endpoint" do
       request = described_class.new(Cassia::AccessController.new)
@@ -41,8 +42,6 @@ RSpec.describe Cassia::Requests::GetToken do
     vcr_options = { cassette_name: 'token/success', record: :new_episodes }
     context "when passing valid credentials", vcr: vcr_options do
       it "returns true" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         request = described_class.new(Cassia::AccessController.new)
 
         response = request.perform
@@ -54,13 +53,13 @@ RSpec.describe Cassia::Requests::GetToken do
     vcr_options = { cassette_name: 'token/failure', record: :new_episodes }
     context "when passing invalid credentials", vcr: vcr_options do
       it "returns false" do
-        Cassia.configuration.client_id = "invalid"
-        Cassia.configuration.secret = "invalid"
-        request = described_class.new(Cassia::AccessController.new)
-        
-        response = request.perform
+        with_environment('CASSIA_CLIENT_ID' => 'invalid', 'CASSIA_SECRET' => 'invalid') do
+          request = described_class.new(Cassia::AccessController.new)
 
-        expect(response).to be_falsey
+          response = request.perform
+
+          expect(response).to be_falsey
+        end
       end
     end
   end

--- a/spec/cassia/requests/open_ap_state_spec.rb
+++ b/spec/cassia/requests/open_ap_state_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Cassia::Requests::OpenApState do
+  include EnvironmentHelpers
+
   describe '#path' do
     it "returns the correct API endpoint" do
       request = described_class.new(Cassia::AccessController.new)
@@ -28,10 +30,8 @@ RSpec.describe Cassia::Requests::OpenApState do
     vcr_options = { cassette_name: 'open_ap_state/success', record: :new_episodes }
       context "when passing in valid aps", vcr: vcr_options do
         it "returns a 202" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new)
-          
+
           response = request.perform
 
           expect(response).to be_truthy
@@ -41,13 +41,13 @@ RSpec.describe Cassia::Requests::OpenApState do
     vcr_options = { cassette_name: 'open_ap_state/failure', record: :new_episodes }
       context "when passing invalid aps", vcr: vcr_options do
         it "returns a 400" do
-          Cassia.configuration.client_id = "invalid client id"
-          Cassia.configuration.secret = "invalid secret"
-          request = described_class.new(Cassia::AccessController.new)
-          
-          response = request.perform
+          with_environment('CASSIA_CLIENT_ID' => 'invalid client id', 'CASSIA_SECRET' => 'invalid secret') do
+            request = described_class.new(Cassia::AccessController.new)
 
-          expect(response).to be_falsey
+            response = request.perform
+
+            expect(response).to be_falsey
+          end
         end
       end
   end

--- a/spec/cassia/requests/open_connection_state_spec.rb
+++ b/spec/cassia/requests/open_connection_state_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cassia::Requests::OpenConnectionState do
   describe '#body' do
     it "returns the correct request" do
       request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"])
-      
+
       expect(request.body).to eq(
         {
           'aps' => ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"]
@@ -40,10 +40,8 @@ RSpec.describe Cassia::Requests::OpenConnectionState do
     vcr_options = { cassette_name: 'open_connection_state/success', record: :new_episodes }
       context "when passing in valid aps", vcr: vcr_options do
         it "returns a 202" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:F1:E8"])
-          
+
           response = request.perform
 
           expect(response).to be_truthy
@@ -53,10 +51,8 @@ RSpec.describe Cassia::Requests::OpenConnectionState do
     vcr_options = { cassette_name: 'open_connection_state/failure', record: :new_episodes }
       context "when passing invalid aps", vcr: vcr_options do
         it "returns a 400" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["invalid router mac"])
-          
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/open_notify_spec.rb
+++ b/spec/cassia/requests/open_notify_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cassia::Requests::OpenNotify do
   describe '#body' do
     it "returns the correct request" do
       request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"])
-      
+
       expect(request.body).to eq(
         {
           'aps' => ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"]
@@ -40,10 +40,8 @@ RSpec.describe Cassia::Requests::OpenNotify do
     vcr_options = { cassette_name: 'open_notify/success', record: :new_episodes }
       context "when passing in valid aps", vcr: vcr_options do
         it "returns a 202" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:F1:E8"])
-          
+
           response = request.perform
 
           expect(response).to be_truthy
@@ -53,10 +51,8 @@ RSpec.describe Cassia::Requests::OpenNotify do
     vcr_options = { cassette_name: 'open_notify/failure', record: :new_episodes }
       context "when passing invalid aps", vcr: vcr_options do
         it "returns a 400" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["invalid router mac"])
-          
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/open_scan_spec.rb
+++ b/spec/cassia/requests/open_scan_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cassia::Requests::OpenScan do
   describe '#body' do
     it "returns the correct request" do
       request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"], chip: 0, active: 1)
-      
+
       expect(request.body).to eq(
         {
           'aps' => ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"],
@@ -42,10 +42,8 @@ RSpec.describe Cassia::Requests::OpenScan do
     vcr_options = { cassette_name: 'open_scan/success', record: :new_episodes }
       context "when passing in valid aps", vcr: vcr_options do
         it "returns a 202" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["CC:1B:E0:E0:ED:AC", "CC:1B:E0:E0:F1:E8"])
-          
+
           response = request.perform
 
           expect(response).to be_truthy
@@ -55,10 +53,8 @@ RSpec.describe Cassia::Requests::OpenScan do
     vcr_options = { cassette_name: 'open_scan/failure', record: :new_episodes }
       context "when passing invalid aps", vcr: vcr_options do
         it "returns a 400" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           request = described_class.new(Cassia::AccessController.new, aps: ["invalid router mac"])
-          
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/requests/switch_autoselect_spec.rb
+++ b/spec/cassia/requests/switch_autoselect_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Cassia::Requests::SwitchAutoselect do
 
     it "returns the correct flag for an off_request" do
       off_request = described_class.new(Cassia::AccessController.new, flag: 0)
-      
+
       expect(off_request.body).to eq(
         {
           'flag' => 0
@@ -50,13 +50,11 @@ RSpec.describe Cassia::Requests::SwitchAutoselect do
     vcr_options = { cassette_name: 'switch_autoselect/success_on', record: :new_episodes }
     context "when passing a valid access token to an on_request", vcr: vcr_options do
       it "returns a 200 response for an on_request" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         request = described_class.new(access_controller, flag: 1)
 
         response = request.perform
-        
+
         expect(response).to be_truthy
       end
     end
@@ -64,8 +62,6 @@ RSpec.describe Cassia::Requests::SwitchAutoselect do
     vcr_options = { cassette_name: 'switch_autoselect/success_off', record: :new_episodes }
     context "when passing a valid access token to an off_request", vcr: vcr_options do
       it "returns a 200 response for an off_request" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         request2 = described_class.new(access_controller, flag: 0)
 
@@ -81,7 +77,7 @@ RSpec.describe Cassia::Requests::SwitchAutoselect do
         access_controller = Cassia::AccessController.new
         access_controller.access_token = "invalid_access_token"
         request = described_class.new(access_controller)
-        
+
         response = request.perform
 
         expect(response).to be_falsey

--- a/spec/cassia/requests/write_char_by_handle_spec.rb
+++ b/spec/cassia/requests/write_char_by_handle_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe Cassia::Requests::WriteCharByHandle do
           char_req = Cassia::Requests::DiscoverAllChar.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
           char_res = char_req.perform
           request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", handle: 3, value: "0100")
-         
+
           response = request.perform
-          
+
           expect(response).to be_truthy
         end
       end
@@ -48,16 +48,14 @@ RSpec.describe Cassia::Requests::WriteCharByHandle do
     vcr_options = { cassette_name: 'write_char_by_handle/failure', record: :new_episodes }
       context "when passing in an invalid handle", vcr: vcr_options do
         it "returns false" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
           connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
           connect_res = connect_req.perform
           char_req = Cassia::Requests::DiscoverAllChar.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44")
           char_res = char_req.perform
-          request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", handle: 100, value: "0100")    
-          
+          request = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", handle: 100, value: "0100")
+
           response = request.perform
 
           expect(response).to be_falsey

--- a/spec/cassia/router_spec.rb
+++ b/spec/cassia/router_spec.rb
@@ -2,13 +2,11 @@ require 'spec_helper'
 
 RSpec.describe Cassia::Router do
   include FaradayHelpers
-  
+
   describe "#connect_local" do
     vcr_options = { cassette_name: 'router/connect_local/success', record: :new_episodes }
       context "when successful", vcr: vcr_options do
         it "adds the device to connected_device" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = Cassia::AccessController.new
           router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
 
@@ -18,12 +16,10 @@ RSpec.describe Cassia::Router do
           expect(access_controller.connected_devices).not_to be_nil
         end
       end
-    
+
     vcr_options = { cassette_name: 'router/connect_local/failure', record: :new_episodes }
       context "when unsuccessful", vcr: vcr_options do
         it "sets the error" do
-          Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-          Cassia.configuration.secret = ENV['CASSIA_SECRET']
           access_controller = described_class.new
           access_controller = Cassia::AccessController.new
           router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
@@ -39,13 +35,11 @@ RSpec.describe Cassia::Router do
     vcr_options = { cassette_name: 'router/disconnect_local/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "removes the device from connected_device" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
         connect_res = connect_req.perform
-        
+
         router.disconnect_local(access_controller, device_mac: "F6:12:3D:BD:DE:44" )
 
         expect(router.connected_devices).to eq []
@@ -56,8 +50,6 @@ RSpec.describe Cassia::Router do
   vcr_options = { cassette_name: 'router/disconnect_local/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = described_class.new
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
@@ -75,8 +67,6 @@ RSpec.describe Cassia::Router do
     vcr_options = { cassette_name: 'router/get_connected_devices_router/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "returns the connected_devices list" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -91,11 +81,9 @@ RSpec.describe Cassia::Router do
   vcr_options = { cassette_name: 'router/get_connected_devices_router/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "invalid router mac")
-        
+
         router.get_connected_devices(access_controller)
 
         expect(access_controller.error). to eq "router's mac is invalid"
@@ -107,8 +95,6 @@ RSpec.describe Cassia::Router do
     vcr_options = { cassette_name: 'router/discover_all_services/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the services of the router" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -119,7 +105,7 @@ RSpec.describe Cassia::Router do
         service1 = Cassia::Service.new(handle: 1, primary: true, uuid: "00001800-0000-1000-8000-00805f9b34fb")
         service2 = Cassia::Service.new(handle: 10, primary: true, uuid: "00001801-0000-1000-8000-00805f9b34fb")
         service3 = Cassia::Service.new(handle: 11, primary: true, uuid: "6e400001-b5a3-f393-e0a9-e50e24dcca9e")
-        
+
         expect(router.connected_devices[0].services).to eq [service1, service2, service3]
       end
     end
@@ -127,13 +113,11 @@ RSpec.describe Cassia::Router do
   vcr_options = { cassette_name: 'router/discover_all_services/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
         connect_res = connect_req.perform
-        
+
         router.discover_all_services(access_controller, device_mac: "F6:12:3D:BD:DE:40")
 
         expect(access_controller.error). to eq "device disconnect"
@@ -145,8 +129,6 @@ RSpec.describe Cassia::Router do
     vcr_options = { cassette_name: 'router/discover_all_char/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the characteristics of the router" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -160,7 +142,7 @@ RSpec.describe Cassia::Router do
         char4 = Cassia::Characteristic.new(uuid: "00002aa6-0000-1000-8000-00805f9b34fb", handle: 9, properties: 2)
         char5 = Cassia::Characteristic.new(uuid: "6e400003-b5a3-f393-e0a9-e50e24dcca9e", handle: 13, properties: 16)
         char6 = Cassia::Characteristic.new(uuid: "6e400002-b5a3-f393-e0a9-e50e24dcca9e", handle: 16, properties: 12)
-        
+
         expect(router.connected_devices[0].characteristics).to eq [char1, char2, char3, char4, char5, char6]
       end
     end
@@ -168,13 +150,11 @@ RSpec.describe Cassia::Router do
   vcr_options = { cassette_name: 'router/discover_all_char/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
         connect_res = connect_req.perform
-        
+
         router.discover_all_char(access_controller, device_mac: "F6:12:3D:BD:DE:40")
 
         expect(access_controller.error). to eq "device disconnect"
@@ -186,8 +166,6 @@ RSpec.describe Cassia::Router do
     vcr_options = { cassette_name: 'router/discover_char_of_service/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the characteristics of a service" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -201,7 +179,7 @@ RSpec.describe Cassia::Router do
         char2 = Cassia::Characteristic.new(uuid: "00002a01-0000-1000-8000-00805f9b34fb", handle: 5, properties: 2)
         char3 = Cassia::Characteristic.new(uuid: "00002a04-0000-1000-8000-00805f9b34fb", handle: 7, properties: 2)
         char4 = Cassia::Characteristic.new(uuid: "00002aa6-0000-1000-8000-00805f9b34fb", handle: 9, properties: 2)
-        
+
         expect(router.connected_devices[0].characteristics).to eq [char1, char2, char3, char4]
       end
     end
@@ -209,8 +187,6 @@ RSpec.describe Cassia::Router do
   vcr_options = { cassette_name: 'router/discover_char_of_service/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -229,8 +205,6 @@ RSpec.describe Cassia::Router do
     vcr_options = { cassette_name: 'router/discover_descriptor_of_char/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the descriptors of a characteristic" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -250,8 +224,6 @@ RSpec.describe Cassia::Router do
   vcr_options = { cassette_name: 'router/discover_descriptor_of_char/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -270,13 +242,11 @@ RSpec.describe Cassia::Router do
     vcr_options = { cassette_name: 'router/discover_all_services_and_chars/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the characteristics of a service and appends it to services" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
         connect_res = connect_req.perform
-        
+
         router.discover_all_services_and_chars(access_controller, device_mac: "F6:12:3D:BD:DE:44")
 
         char1 = Cassia::Characteristic.new(uuid: "00002a00-0000-1000-8000-00805f9b34fb", handle: 3, properties: 10, descriptors: [{"handle"=>3, "uuid"=>"00002a00-0000-1000-8000-00805f9b34fb"}])
@@ -286,7 +256,7 @@ RSpec.describe Cassia::Router do
         char5 = Cassia::Characteristic.new(uuid: "6e400003-b5a3-f393-e0a9-e50e24dcca9e", handle: 13, properties: 16, descriptors: [{"handle"=>13, "uuid"=>"6e400003-b5a3-f393-e0a9-e50e24dcca9e"}, {"handle"=>14, "uuid"=>"00002902-0000-1000-8000-00805f9b34fb"}])
         char6 = Cassia::Characteristic.new(uuid: "6e400002-b5a3-f393-e0a9-e50e24dcca9e", handle: 16, properties: 12, descriptors: [{"handle"=>16, "uuid"=>"6e400002-b5a3-f393-e0a9-e50e24dcca9e"}])
         service1 = Cassia::Service.new(uuid: "00001800-0000-1000-8000-00805f9b34fb", primary: true, characteristics: [char1, char2, char3, char4], handle: 1)
-        
+
         expect(router.connected_devices[0].characteristics).to eq [char1, char2, char3, char4, char5, char6]
         expect(router.connected_devices[0].services).to include service1
       end
@@ -295,13 +265,11 @@ RSpec.describe Cassia::Router do
   vcr_options = { cassette_name: 'router/discover_all_services_and_chars/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
         connect_res = connect_req.perform
-        
+
         router.discover_all_services_and_chars(access_controller, device_mac: "F6:12:3D:BD:DE:40")
 
         expect(access_controller.error). to eq "device disconnect"
@@ -313,8 +281,6 @@ RSpec.describe Cassia::Router do
     vcr_options = { cassette_name: 'router/write_char_by_handle/success', record: :new_episodes }
     context "when successful", vcr: vcr_options do
       it "sets the notification_on attribute to true of a characteristic" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -329,8 +295,6 @@ RSpec.describe Cassia::Router do
       end
 
       it "sets the notification_on attribute to false of a characteristic" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")
@@ -348,8 +312,6 @@ RSpec.describe Cassia::Router do
   vcr_options = { cassette_name: 'router/write_char_by_handle/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error" do
-        Cassia.configuration.client_id = ENV['CASSIA_CLIENT_ID']
-        Cassia.configuration.secret = ENV['CASSIA_SECRET']
         access_controller = Cassia::AccessController.new
         router = described_class.new(mac: "CC:1B:E0:E0:F1:E8")
         connect_req = Cassia::Requests::ConnectLocal.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", type: "random")

--- a/spec/support/environment_helpers.rb
+++ b/spec/support/environment_helpers.rb
@@ -1,0 +1,11 @@
+module EnvironmentHelpers
+  def with_environment(partial_env)
+    old = ENV.to_hash
+    ENV.update partial_env
+    begin
+      yield
+    ensure
+      ENV.replace old
+    end
+  end
+end


### PR DESCRIPTION
Add a helper that will allow us to change environment variables during
tests. This will allow us to dynamically change the client id and
client secret so we can mock failures and successful api requests better
in our code.