### PR TITLE
Properly handle error from write char by handle

### DIFF
--- a/lib/cassia/response_handlers/write_char_by_handle.rb
+++ b/lib/cassia/response_handlers/write_char_by_handle.rb
@@ -34,8 +34,7 @@ module Cassia
       end
 
       def handle_failure(response)
-        @access_controller.error = JSON.parse(response.body)['error']
-        @access_controller.error_description = JSON.parse(response.body)['error_description']
+        @access_controller.error = response.body
       end
     end
   end

--- a/spec/cassia/response_handlers/write_char_by_handle_spec.rb
+++ b/spec/cassia/response_handlers/write_char_by_handle_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe Cassia::ResponseHandlers::WriteCharByHandle do
       it "sets the error on the access controller" do
         access_controller = Cassia::AccessController.new
         router = Cassia::Router.new(mac: "CC:1B:E0:E0:F1:E8")
-        response = build_response(status: 500, body: {error: 'Error message'}.to_json)
+        response = build_response(status: 500, body: 'device disconnect')
 
         response_handler = described_class.new(access_controller, router: router, device_mac: "F6:12:3D:BD:DE:44", handle: 100, value: "32" )
 
         result = response_handler.handle(response)
 
-        expect(access_controller.error). to eq('Error message')
+        expect(access_controller.error). to eq('device disconnect')
       end
     end
   end


### PR DESCRIPTION
When we get a 500 because the device is disconnected we want to make
sure that we can access the error properly and not cause another error.