### PR TITLE
Get new auth token on expiration

### DIFF
--- a/lib/cassia/access_controller.rb
+++ b/lib/cassia/access_controller.rb
@@ -3,6 +3,7 @@ module Cassia
     include Virtus.model
 
     attribute :access_token, String
+    attribute :access_token_expiration, Time, default: Time.now.getutc + 100 # default for tests when we pass in access token
     attribute :error, String
     attribute :error_description, String
     attribute :autoselect_switch, Integer, default: 0
@@ -11,7 +12,8 @@ module Cassia
     attribute :sse
 
     def get_token
-      Cassia::Requests::GetToken.new(self).perform
+      Cassia::Requests::GetToken.new(self).perform if access_token.nil? || Time.now.getutc > access_token_expiration
+      access_token
     end
 
     def get_all_routers_status
@@ -89,7 +91,7 @@ module Cassia
     def discover_all_services_and_chars(router: , device_mac: )
       Cassia::Requests::DiscoverAllServicesAndChars.new(self, router: router, device_mac: device_mac).perform
     end
-    
+
     def write_char_by_handle(router: , device_mac:, handle: , value: )
       Cassia::Requests::WriteCharByHandle.new(self, router: router, device_mac: device_mac, handle: handle, value: value).perform
     end
@@ -97,7 +99,7 @@ module Cassia
     def open_char_notification(router: , device_mac: , handle: )
       Cassia::Requests::WriteCharByHandle.new(self, router: router, device_mac: device_mac, handle: handle, value: "0100").perform
     end
-    
+
     def close_char_notification(router: , device_mac: , handle: )
       Cassia::Requests::WriteCharByHandle.new(self, router: router, device_mac: device_mac, handle: handle, value: "0000").perform
     end

--- a/lib/cassia/requests/close_ap_state.rb
+++ b/lib/cassia/requests/close_ap_state.rb
@@ -11,20 +11,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::CloseApState.new(@access_controller).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/close_connection_state.rb
+++ b/lib/cassia/requests/close_connection_state.rb
@@ -18,20 +18,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::CloseConnectionState.new(@access_controller, aps: @aps).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/close_notify.rb
+++ b/lib/cassia/requests/close_notify.rb
@@ -18,20 +18,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::CloseNotify.new(@access_controller, aps: @aps).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/close_scan.rb
+++ b/lib/cassia/requests/close_scan.rb
@@ -18,20 +18,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::CloseScan.new(@access_controller, aps: @aps).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/combined_sse.rb
+++ b/lib/cassia/requests/combined_sse.rb
@@ -11,16 +11,9 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/connect_device.rb
+++ b/lib/cassia/requests/connect_device.rb
@@ -18,20 +18,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::ConnectDevice.new(@access_controller).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/connect_local.rb
+++ b/lib/cassia/requests/connect_local.rb
@@ -24,20 +24,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::ConnectLocal.new(@access_controller, router: @router, device_mac: @device_mac).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/disconnect_device.rb
+++ b/lib/cassia/requests/disconnect_device.rb
@@ -16,20 +16,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::DisconnectDevice.new(@access_controller).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/disconnect_local.rb
+++ b/lib/cassia/requests/disconnect_local.rb
@@ -13,20 +13,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::DisconnectLocal.new(@access_controller, router: @router, device_mac: @device_mac).handle(Cassia.api.delete(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/discover_all_char.rb
+++ b/lib/cassia/requests/discover_all_char.rb
@@ -13,20 +13,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::DiscoverAllChar.new(@access_controller, router: @router, device_mac: @device_mac).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/discover_all_services.rb
+++ b/lib/cassia/requests/discover_all_services.rb
@@ -13,20 +13,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::DiscoverAllServices.new(@access_controller, router: @router, device_mac: @device_mac).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/discover_all_services_and_chars.rb
+++ b/lib/cassia/requests/discover_all_services_and_chars.rb
@@ -13,20 +13,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::DiscoverAllServicesAndChars.new(@access_controller, router: @router, device_mac: @device_mac).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/discover_char_of_service.rb
+++ b/lib/cassia/requests/discover_char_of_service.rb
@@ -14,20 +14,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::DiscoverCharOfService.new(@access_controller, router: @router, device_mac: @device_mac, service_uuid: @service_uuid).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/discover_descriptor_of_char.rb
+++ b/lib/cassia/requests/discover_descriptor_of_char.rb
@@ -14,20 +14,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::DiscoverDescriptorOfChar.new(@access_controller, router: @router, device_mac: @device_mac, char_uuid: @char_uuid).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/get_all_routers_status.rb
+++ b/lib/cassia/requests/get_all_routers_status.rb
@@ -13,20 +13,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::GetAllRoutersStatus.new(@access_controller).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/get_connected_devices_router.rb
+++ b/lib/cassia/requests/get_connected_devices_router.rb
@@ -14,20 +14,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::GetConnectedDevicesRouter.new(@access_controller, router: @router).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/open_ap_state.rb
+++ b/lib/cassia/requests/open_ap_state.rb
@@ -11,20 +11,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::OpenApState.new(@access_controller).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/open_connection_state.rb
+++ b/lib/cassia/requests/open_connection_state.rb
@@ -18,20 +18,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::OpenConnectionState.new(@access_controller, aps: @aps).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/open_notify.rb
+++ b/lib/cassia/requests/open_notify.rb
@@ -18,20 +18,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::OpenNotify.new(@access_controller, aps: @aps).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/open_scan.rb
+++ b/lib/cassia/requests/open_scan.rb
@@ -30,20 +30,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::OpenScan.new(@access_controller, aps: @aps).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/switch_autoselect.rb
+++ b/lib/cassia/requests/switch_autoselect.rb
@@ -17,20 +17,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::SwitchAutoselect.new(@access_controller).handle(Cassia.api.post(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/requests/write_char_by_handle.rb
+++ b/lib/cassia/requests/write_char_by_handle.rb
@@ -15,20 +15,13 @@ module Cassia
 
       def headers
         {
-          'Authorization' => "Bearer #{access_token}",
+          'Authorization' => "Bearer #{@access_controller.get_token}",
           'Content-Type' => "application/json"
         }
       end
 
       def perform
         Cassia::ResponseHandlers::WriteCharByHandle.new(@access_controller, router: @router, device_mac: @device_mac, handle: @handle, value: @value).handle(Cassia.api.get(self))
-      end
-
-      private
-
-      def access_token
-        @access_controller.get_token if @access_controller.access_token.nil?
-        @access_controller.access_token
       end
     end
   end

--- a/lib/cassia/response_handlers/get_token.rb
+++ b/lib/cassia/response_handlers/get_token.rb
@@ -18,6 +18,9 @@ module Cassia
 
       def handle_success(response)
         @access_controller.access_token = response.body["access_token"]
+        # set the token expiration for 3500 seconds from now, the actual expiration is 3600
+        # but this gives some buffer
+        @access_controller.access_token_expiration = Time.now.getutc + 3500
       end
 
       def handle_failure(response)

--- a/spec/cassettes/routersstatus/failure.yml
+++ b/spec/cassettes/routersstatus/failure.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: <API_URL>/api/cassia/hubs
+    uri: http://staging-cassia.<CLIENT_ID>.co/api/cassia/hubs
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,53 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"forbidden","error_description":"Token not found or expired"}'
-    http_version:
+    http_version: 
   recorded_at: Fri, 21 Jun 2019 19:11:29 GMT
+- request:
+    method: post
+    uri: http://staging-cassia.<CLIENT_ID>.co/api/oauth2/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials"}'
+    headers:
+      Authorization:
+      - Basic aW52YWxpZCBjbGllbnQgaWQ6aW52YWxpZCBzZWNyZXQ=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      server:
+      - nginx/1.13.6
+      date:
+      - Fri, 11 Oct 2019 15:07:03 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '65'
+      connection:
+      - close
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-headers:
+      - Content-Type,Accept,Authorization
+      access-control-allow-methods:
+      - GET,POST,PUT,DELETE
+      access-control-allow-credentials:
+      - 'true'
+      x-frame-options:
+      - SAMEORIGIN
+      x-content-type-options:
+      - nosniff
+      cache-control:
+      - no-store
+      pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '{"error":"invalid_client","error_description":"Client not found"}'
+    http_version: 
+  recorded_at: Fri, 11 Oct 2019 15:07:03 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/switch_autoselect/failure.yml
+++ b/spec/cassettes/switch_autoselect/failure.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: <API_URL>/api/aps/ap-select-switch
+    uri: http://staging-cassia.<CLIENT_ID>.co/api/aps/ap-select-switch
     body:
       encoding: UTF-8
       string: '{"flag":1}'
@@ -43,6 +43,53 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"forbidden","error_description":"Token not found or expired"}'
-    http_version:
+    http_version: 
   recorded_at: Fri, 21 Jun 2019 19:11:28 GMT
+- request:
+    method: post
+    uri: http://staging-cassia.<CLIENT_ID>.co/api/oauth2/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials"}'
+    headers:
+      Authorization:
+      - Basic dGVzdDoxMjM0NQ==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      server:
+      - nginx/1.13.6
+      date:
+      - Fri, 11 Oct 2019 15:07:03 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '65'
+      connection:
+      - close
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-headers:
+      - Content-Type,Accept,Authorization
+      access-control-allow-methods:
+      - GET,POST,PUT,DELETE
+      access-control-allow-credentials:
+      - 'true'
+      x-frame-options:
+      - SAMEORIGIN
+      x-content-type-options:
+      - nosniff
+      cache-control:
+      - no-store
+      pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '{"error":"invalid_client","error_description":"Client not found"}'
+    http_version: 
+  recorded_at: Fri, 11 Oct 2019 15:07:03 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassia/access_controller_spec.rb
+++ b/spec/cassia/access_controller_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe Cassia::AccessController do
       end
     end
 
+    context "when the token is expired", vcr: vcr_options do
+      it "gets a new access_token" do
+        access_controller = described_class.new(access_token: 'old_token', access_token_expiration: Time.now.getutc - 30)
+
+        access_controller.get_token
+
+        expect(access_controller.access_token).not_to eq('old_token')
+      end
+    end
+
+    context "when the token is not expired and already exists" do
+      it "returns the current token" do
+        access_controller = described_class.new(access_token: 'current_token', access_token_expiration: Time.now.getutc + 1000)
+
+        access_controller.get_token
+
+        expect(access_controller.access_token).to eq('current_token')
+      end
+    end
+
     vcr_options = { cassette_name: 'access_controller/get_token/failure', record: :new_episodes }
     context "when unsuccessful", vcr: vcr_options do
       it "sets the error and error_description values" do


### PR DESCRIPTION
Check the auth token's expiration so that we can get a new one if
it's about to expire. Move this logic into the `get_token` method.
Hoping to make 403's less common in client applications.