### PR TITLE
Use sets for routers and connected devices

### DIFF
--- a/lib/cassia/access_controller.rb
+++ b/lib/cassia/access_controller.rb
@@ -7,8 +7,8 @@ module Cassia
     attribute :error, String
     attribute :error_description, String
     attribute :autoselect_switch, Integer, default: 0
-    attribute :connected_devices, Array[Cassia::Device], default: []
-    attribute :routers, Array[Cassia::Router], default: []
+    attribute :connected_devices, Set[Cassia::Device], default: []
+    attribute :routers, Set[Cassia::Router], default: []
     attribute :sse
 
     def get_token

--- a/lib/cassia/device.rb
+++ b/lib/cassia/device.rb
@@ -10,5 +10,13 @@ module Cassia
     attribute :connectionState, String
     attribute :services, Array[Cassia::Service]
     attribute :characteristics, Array[Cassia::Characteristic]
+
+    def ==(other)
+      return self.mac == other.mac
+    end
+
+    def eql?(other)
+      return self.mac == other.mac
+    end
   end
 end

--- a/lib/cassia/router.rb
+++ b/lib/cassia/router.rb
@@ -22,11 +22,19 @@ module Cassia
     attribute :update_progress, Integer
     attribute :container, Hash
     attribute :ap, Hash
-    attribute :connected_devices, Array[Cassia::Device], default: []
+    attribute :connected_devices, Set[Cassia::Device], default: []
     attribute :notification_open, Boolean
     attribute :scanning_on, Boolean
     attribute :connection_state_monitor_on, Boolean
     attribute :ap_state_monitor_on, Boolean
+
+    def ==(other)
+      return self.mac == other.mac
+    end
+
+    def eql?(other)
+      return self.mac == other.mac
+    end
 
     def connect_local(access_controller, device_mac: , type: )
       Cassia::Requests::ConnectLocal.new(access_controller, router: self, device_mac: device_mac, type: type).perform
@@ -67,7 +75,7 @@ module Cassia
     def open_char_notification(access_controller, device_mac: , handle: )
       Cassia::Requests::WriteCharByHandle.new(access_controller, router: self, device_mac: device_mac, handle: handle, value: "0100").perform
     end
-    
+
     def close_char_notification(access_controller, device_mac: , handle: )
       Cassia::Requests::WriteCharByHandle.new(access_controller, router: self, device_mac: device_mac, handle: handle, value: "0000").perform
     end

--- a/spec/cassia/access_controller_spec.rb
+++ b/spec/cassia/access_controller_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe Cassia::AccessController do
           service2 = Cassia::Service.new(handle: 10, primary: true, uuid: "00001801-0000-1000-8000-00805f9b34fb")
           service3 = Cassia::Service.new(handle: 11, primary: true, uuid: "6e400001-b5a3-f393-e0a9-e50e24dcca9e")
 
-          expect(access_controller.connected_devices[0].services).to eq([service1, service2, service3])
+          expect(access_controller.connected_devices.first.services).to eq([service1, service2, service3])
         end
       end
 
@@ -372,7 +372,7 @@ RSpec.describe Cassia::AccessController do
         char5 = Cassia::Characteristic.new(uuid: "6e400003-b5a3-f393-e0a9-e50e24dcca9e", handle: 13, properties: 16)
         char6 = Cassia::Characteristic.new(uuid: "6e400002-b5a3-f393-e0a9-e50e24dcca9e", handle: 16, properties: 12)
 
-        expect(access_controller.connected_devices[0].characteristics).to eq [char1, char2, char3, char4, char5, char6]
+        expect(access_controller.connected_devices.first.characteristics).to eq [char1, char2, char3, char4, char5, char6]
       end
     end
 
@@ -409,7 +409,7 @@ RSpec.describe Cassia::AccessController do
         char3 = Cassia::Characteristic.new(uuid: "00002a04-0000-1000-8000-00805f9b34fb", handle: 7, properties: 2)
         char4 = Cassia::Characteristic.new(uuid: "00002aa6-0000-1000-8000-00805f9b34fb", handle: 9, properties: 2)
 
-        expect(access_controller.connected_devices[0].characteristics).to eq [char1, char2, char3, char4]
+        expect(access_controller.connected_devices.first.characteristics).to eq [char1, char2, char3, char4]
       end
     end
 
@@ -443,7 +443,7 @@ RSpec.describe Cassia::AccessController do
 
         access_controller.discover_descriptor_of_char(router: router, device_mac: "F6:12:3D:BD:DE:44", char_uuid: "00002a00-0000-1000-8000-00805f9b34fb")
 
-        char = access_controller.connected_devices[0].characteristics.detect {|char| char.uuid == "00002a00-0000-1000-8000-00805f9b34fb"}
+        char = access_controller.connected_devices.first.characteristics.detect {|char| char.uuid == "00002a00-0000-1000-8000-00805f9b34fb"}
         descriptor = Cassia::Descriptor.new(handle: 3, uuid: "00002a00-0000-1000-8000-00805f9b34fb")
         expect(char.descriptors).to eq [descriptor]
       end
@@ -485,8 +485,8 @@ RSpec.describe Cassia::AccessController do
         char6 = Cassia::Characteristic.new(uuid: "6e400002-b5a3-f393-e0a9-e50e24dcca9e", handle: 16, properties: 12, descriptors: [{"handle"=>16, "uuid"=>"6e400002-b5a3-f393-e0a9-e50e24dcca9e"}])
         service1 = Cassia::Service.new(uuid: "00001800-0000-1000-8000-00805f9b34fb", primary: true, characteristics: [char1, char2, char3, char4], handle: 1)
 
-        expect(access_controller.connected_devices[0].characteristics).to eq [char1, char2, char3, char4, char5, char6]
-        expect(access_controller.connected_devices[0].services).to include service1
+        expect(access_controller.connected_devices.first.characteristics).to eq [char1, char2, char3, char4, char5, char6]
+        expect(access_controller.connected_devices.first.services).to include service1
       end
     end
 
@@ -518,7 +518,7 @@ RSpec.describe Cassia::AccessController do
 
         access_controller.write_char_by_handle(router: router, device_mac: "F6:12:3D:BD:DE:44", handle: 3, value: "0100")
 
-        char = access_controller.connected_devices[0].characteristics.detect {|char| char.handle == 3}
+        char = access_controller.connected_devices.first.characteristics.detect {|char| char.handle == 3}
         expect(char.notification_on).to eq true
       end
 
@@ -532,7 +532,7 @@ RSpec.describe Cassia::AccessController do
 
         access_controller.write_char_by_handle(router: router, device_mac: "F6:12:3D:BD:DE:44", handle: 3, value: "0000")
 
-        char = access_controller.connected_devices[0].characteristics.detect {|char| char.handle == 3}
+        char = access_controller.connected_devices.first.characteristics.detect {|char| char.handle == 3}
         expect(char.notification_on).to eq false
       end
     end

--- a/spec/cassia/devices_spec.rb
+++ b/spec/cassia/devices_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe Cassia::Device do
+  describe "#==" do
+    it "returns true for two matching routers by mac" do
+      router1 = described_class.new(mac: '1', )
+      router2 = described_class.new(mac: '1')
+
+      expect(router1==router2).to be_truthy
+    end
+
+    it "returns false for two routers with differnet macs" do
+      router1 = described_class.new(mac: '1')
+      router2 = described_class.new(mac: '2')
+
+      expect(router1==router2).to be_falsey
+    end
+  end
+
+  describe "#eql?" do
+    it "returns true for two matching routers by mac" do
+      router1 = described_class.new(mac: '1')
+      router2 = described_class.new(mac: '1')
+
+      expect(router1==router2).to be_truthy
+    end
+
+    it "returns false for two routers with differnet macs" do
+      router1 = described_class.new(mac: '1')
+      router2 = described_class.new(mac: '2')
+
+      expect(router1==router2).to be_falsey
+    end
+  end
+end

--- a/spec/cassia/router_spec.rb
+++ b/spec/cassia/router_spec.rb
@@ -3,6 +3,38 @@ require 'spec_helper'
 RSpec.describe Cassia::Router do
   include FaradayHelpers
 
+  describe "#==" do
+    it "returns true for two matching routers by mac" do
+      router1 = described_class.new(mac: '1')
+      router2 = described_class.new(mac: '1')
+
+      expect(router1==router2).to be_truthy
+    end
+
+    it "returns false for two routers with differnet macs" do
+      router1 = described_class.new(mac: '1')
+      router2 = described_class.new(mac: '2')
+
+      expect(router1==router2).to be_falsey
+    end
+  end
+
+  describe "#eql?" do
+    it "returns true for two matching routers by mac" do
+      router1 = described_class.new(mac: '1')
+      router2 = described_class.new(mac: '1')
+
+      expect(router1==router2).to be_truthy
+    end
+
+    it "returns false for two routers with differnet macs" do
+      router1 = described_class.new(mac: '1')
+      router2 = described_class.new(mac: '2')
+
+      expect(router1==router2).to be_falsey
+    end
+  end
+
   describe "#connect_local" do
     vcr_options = { cassette_name: 'router/connect_local/success', record: :new_episodes }
       context "when successful", vcr: vcr_options do
@@ -42,8 +74,8 @@ RSpec.describe Cassia::Router do
 
         router.disconnect_local(access_controller, device_mac: "F6:12:3D:BD:DE:44" )
 
-        expect(router.connected_devices).to eq []
-        expect(access_controller.connected_devices).to eq []
+        expect(router.connected_devices).to eq Set[]
+        expect(access_controller.connected_devices).to eq Set[]
       end
     end
 
@@ -74,7 +106,7 @@ RSpec.describe Cassia::Router do
 
         router.get_connected_devices(access_controller)
 
-        expect(router.connected_devices[0].mac).to eq "F6:12:3D:BD:DE:44"
+        expect(router.connected_devices.first.mac).to eq "F6:12:3D:BD:DE:44"
       end
     end
 
@@ -106,7 +138,7 @@ RSpec.describe Cassia::Router do
         service2 = Cassia::Service.new(handle: 10, primary: true, uuid: "00001801-0000-1000-8000-00805f9b34fb")
         service3 = Cassia::Service.new(handle: 11, primary: true, uuid: "6e400001-b5a3-f393-e0a9-e50e24dcca9e")
 
-        expect(router.connected_devices[0].services).to eq [service1, service2, service3]
+        expect(router.connected_devices.first.services).to eq [service1, service2, service3]
       end
     end
 
@@ -143,7 +175,7 @@ RSpec.describe Cassia::Router do
         char5 = Cassia::Characteristic.new(uuid: "6e400003-b5a3-f393-e0a9-e50e24dcca9e", handle: 13, properties: 16)
         char6 = Cassia::Characteristic.new(uuid: "6e400002-b5a3-f393-e0a9-e50e24dcca9e", handle: 16, properties: 12)
 
-        expect(router.connected_devices[0].characteristics).to eq [char1, char2, char3, char4, char5, char6]
+        expect(router.connected_devices.first.characteristics).to eq [char1, char2, char3, char4, char5, char6]
       end
     end
 
@@ -180,7 +212,7 @@ RSpec.describe Cassia::Router do
         char3 = Cassia::Characteristic.new(uuid: "00002a04-0000-1000-8000-00805f9b34fb", handle: 7, properties: 2)
         char4 = Cassia::Characteristic.new(uuid: "00002aa6-0000-1000-8000-00805f9b34fb", handle: 9, properties: 2)
 
-        expect(router.connected_devices[0].characteristics).to eq [char1, char2, char3, char4]
+        expect(router.connected_devices.first.characteristics).to eq [char1, char2, char3, char4]
       end
     end
 
@@ -216,7 +248,7 @@ RSpec.describe Cassia::Router do
 
         router.discover_descriptor_of_char(access_controller, device_mac: "F6:12:3D:BD:DE:44", char_uuid: "00002a00-0000-1000-8000-00805f9b34fb")
 
-        char = router.connected_devices[0].characteristics.detect {|char| char.uuid == "00002a00-0000-1000-8000-00805f9b34fb"}
+        char = router.connected_devices.first.characteristics.detect {|char| char.uuid == "00002a00-0000-1000-8000-00805f9b34fb"}
         descriptor = Cassia::Descriptor.new(handle: 3, uuid: "00002a00-0000-1000-8000-00805f9b34fb")
         expect(char.descriptors).to eq [descriptor]
       end
@@ -258,8 +290,8 @@ RSpec.describe Cassia::Router do
         char6 = Cassia::Characteristic.new(uuid: "6e400002-b5a3-f393-e0a9-e50e24dcca9e", handle: 16, properties: 12, descriptors: [{"handle"=>16, "uuid"=>"6e400002-b5a3-f393-e0a9-e50e24dcca9e"}])
         service1 = Cassia::Service.new(uuid: "00001800-0000-1000-8000-00805f9b34fb", primary: true, characteristics: [char1, char2, char3, char4], handle: 1)
 
-        expect(router.connected_devices[0].characteristics).to eq [char1, char2, char3, char4, char5, char6]
-        expect(router.connected_devices[0].services).to include service1
+        expect(router.connected_devices.first.characteristics).to eq [char1, char2, char3, char4, char5, char6]
+        expect(router.connected_devices.first.services).to include service1
       end
     end
 
@@ -291,7 +323,7 @@ RSpec.describe Cassia::Router do
 
         router.write_char_by_handle(access_controller, device_mac: "F6:12:3D:BD:DE:44", handle: 3, value: "0100")
 
-        char = router.connected_devices[0].characteristics.detect {|char| char.handle == 3}
+        char = router.connected_devices.first.characteristics.detect {|char| char.handle == 3}
         expect(char.notification_on).to eq true
       end
 
@@ -305,7 +337,7 @@ RSpec.describe Cassia::Router do
 
         router.write_char_by_handle(access_controller, device_mac: "F6:12:3D:BD:DE:44", handle: 3, value: "0000")
 
-        char = router.connected_devices[0].characteristics.detect {|char| char.handle == 3}
+        char = router.connected_devices.first.characteristics.detect {|char| char.handle == 3}
         expect(char.notification_on).to eq false
       end
     end


### PR DESCRIPTION
With this change we will use ruby Set's for routers and connected
devices instead of arrays. This will ensure that we don't add
routers and connected devices if they already exist in the set.